### PR TITLE
Fix lab issues #167, #150, #158 (DLP wizard label, Graph module, PowerShell note)

### DIFF
--- a/Instructions/Labs/LAB_AK_01_Lab1_Ex1_Initialize_M365_Tenant.md
+++ b/Instructions/Labs/LAB_AK_01_Lab1_Ex1_Initialize_M365_Tenant.md
@@ -278,15 +278,18 @@ Microsoft Graph PowerShell is required to perform several configuration tasks wh
 	Get-InstalledModule Microsoft.Graph.* | select *name*
 	```
 
-5. Verify the list of installed sub-modules includes the following three sub-modules that will be used in later lab exercises: 
+5. Verify the list of installed sub-modules includes the following four sub-modules that will be used in later lab exercises: 
 
 	```powershell
 	- Microsoft.Graph.Groups
 	- Microsoft.Graph.Identity.DirectoryManagement
+	- Microsoft.Graph.Identity.Governance
  	- Microsoft.Graph.Users
 	```
   	
-	If all three sub-modules appear in the list of installed sub-modules, then proceed to the next step. However, if any of these three sub-modules do not appear in the list, then run the following PowerShell command to manually install the missing sub-module:
+	**Note:** The **Microsoft.Graph.Identity.Governance** sub-module is required in Lab 2, Exercise 1, Task 3 (Assign an administrator role using Windows PowerShell), so be sure to verify it installed.
+  	
+	If all four sub-modules appear in the list of installed sub-modules, then proceed to the next step. However, if any of these sub-modules do not appear in the list, then run the following PowerShell command to manually install the missing sub-module:
 
 	```powershell
 	Install-Module -Name <module name> -Scope CurrentUser

--- a/Instructions/Labs/LAB_AK_03_Lab3_Ex2_Implement_Identity_Synch.md
+++ b/Instructions/Labs/LAB_AK_03_Lab3_Ex2_Implement_Identity_Synch.md
@@ -22,7 +22,9 @@ In this task, you will run the Microsoft Entra Connect Sync setup wizard to enab
 
 **IMPORTANT:** Azure Active Directory (Azure AD) was rebranded to Microsoft Entra ID in August, 2023. As such, all Azure AD product features are being rebranded to Microsoft Entra. Since this rebranding effort is still on-going, some Azure AD features have not yet been rebranded to Microsoft Entra. For example, the original name of Microsoft Entra Connect Sync was Azure AD Connect. As of this writing, the filename still refers to AzureADConnect. Keep this in mind if you see Azure AD still referenced on Microsoft 365 pages, product names. Microsoft World Wide Learning will strive to keep these lab instructions updated as the Microsoft 365 Engineering team continues its rebranding efforts.
 
-1. You should still be logged into **LON-DC1** as **adatum\administrator** from the prior task. 
+1. You should still be logged into **LON-DC1** as **adatum\administrator** from the prior task. <br/>
+
+	**Note:** If a **Windows PowerShell** window is open on LON-DC1 from a prior exercise, close it now before proceeding. The Microsoft Entra Connect Sync setup that you perform in this task installs the ADSync PowerShell module. If a PowerShell window was opened *before* that installation, the **Start-ADSyncSyncCycle** cmdlet used later in Task 4 won't be available in that session, and you'll receive a "cmdlet is not recognized" error.
 
 2. After finishing the earlier lab exercise in which you added Adatum's custom domain, you should still be logged into Microsoft 365 in your Edge browser as Holly Dickson.  
 

--- a/Instructions/Labs/LAB_AK_04_Lab4_Ex1_Manage_secure_user_access.md
+++ b/Instructions/Labs/LAB_AK_04_Lab4_Ex1_Manage_secure_user_access.md
@@ -33,7 +33,7 @@ Adatum has directed Holly to enable MFA for all its Microsoft 365 users - both i
 
 4. In the **Microsoft Entra admin center**, under **Entra ID** in the navigation pane, select **Authentication methods**.
 
-5. One the **Authentication methods** page, select **SMS** and then toggle the slider to **Enable** and then at the bottom of the page, select **Save**.
+5. On the **Authentication methods** page, select **SMS** and then toggle the slider to **Enable** and then at the bottom of the page, select **Save**.
 
 6. In the **Microsoft Entra admin center**, under **Entra ID** in the navigation pane, select **Conditional Access**.
 

--- a/Instructions/Labs/LAB_AK_08_Lab8_Ex1_Manage_DLP_Policies.md
+++ b/Instructions/Labs/LAB_AK_08_Lab8_Ex1_Manage_DLP_Policies.md
@@ -27,7 +27,7 @@ The policy will contain two rules, or actions, each of which is dependent on the
 
 4. In the **Policies** page, select the **+Create policy** option on the menu bar to start the **Create policy** wizard.
 
-5. On the **Choose what type of data to protect** page, select **Data stored in connected sources** and then select **Next** 
+5. On the **Choose the type of data to protect** page, select **Enterprise applications and devices** and then select **Next** 
 
 6. On the **Start with a template or create a custom policy** page, the **Categories** column displays the policy categories. Each policy category provide Regulations that can be used to create that type of policy, except for the **Custom** category. This category does not provide any specific template; instead, it enables organizations to create custom policies from scratch. When you select a category, **Regulations** column appears that displays the available Regulations to choose from for the selected category. When you select a template, another column appears that displays the type of information that is protected in that template. <br/> 
 


### PR DESCRIPTION
Batch of easy, verified lab-content fixes from the open-issue triage.

## Fixes
- **#167** — Lab 8 Ex 1, Task 1: the DLP "Choose the type of data to protect" wizard page no longer offers "Data stored in connected sources". Updated the selection to **Enterprise applications and devices** (verified against the current [Create and deploy a DLP policy](https://learn.microsoft.com/en-us/purview/dlp-create-deploy-policy) docs, whose scenarios are organized under "Enterprise applications & devices").
- **#150** — Lab 1 Ex 1, Task 4: added **Microsoft.Graph.Identity.Governance** to the list of sub-modules to verify, with a note that it's required in Lab 2 Ex 1 Task 3.
- **#158** — Lab 3 Ex 2, Task 1: added a proactive note to close any open PowerShell window **before** the Entra Connect Sync install, so the `Start-ADSyncSyncCycle` cmdlet is available in Task 4. (The existing Task 4 warning remains as a safety net.)
- **Follow-up to #155** — Lab 4 Ex 1: fixed a "One the" → "On the" typo introduced by the just-merged post-delivery fixes PR.

## Notes
- Verified against current Microsoft Learn / Purview / Exchange docs where UI or module names were involved.
- Held from this batch: #146 (Lab 4 PIM navigation) needs live-portal confirmation and overlaps the areas #155 just rewrote.