### PR TITLE
Fix #152/#156: soften org information language for read-only fields (Lab 1 Ex 1)

### DIFF
--- a/Instructions/Labs/LAB_AK_01_Lab1_Ex1_Initialize_M365_Tenant.md
+++ b/Instructions/Labs/LAB_AK_01_Lab1_Ex1_Initialize_M365_Tenant.md
@@ -93,9 +93,9 @@ Throughout the labs in this course, you will role-play by taking on the persona 
 
 15. In the **Organization profile** tab, select **Organization information** from the list of profile data.
 
-16. In the **Organization information** pane that appears, enter the following information: <br/>
+16. In the **Organization information** pane that appears, review the organization details. If the following fields are editable in your tenant, update them as shown. Some trial tenants no longer allow all of these values to be changed in the Microsoft 365 admin center - in particular, the organization **Name** is often read-only here. If a field is unavailable or read-only, leave it as-is and continue; this won't affect any later lab steps. <br/>
 
-    - Name: **Adatum Corporation** (Note: Adatum Corporation is a subsidiary of Contoso Inc. The Microsoft trial tenant that your lab hosting provider obtained for this lab may have been originally assigned to Contoso. If **Contoso** (or any other value) appears as the organization name, then change it to **Adatum Corporation**.)
+    - Name: **Adatum Corporation** (Note: Adatum Corporation is a subsidiary of Contoso Inc. Your trial tenant may already display **Contoso** or another value. If the **Name** field is editable, change it to **Adatum Corporation**; if it's read-only, leave the displayed name as-is - later labs work regardless of the organization name shown.)
 
     - Street Address: **555 Main Street**
 


### PR DESCRIPTION
Fixes #152, #156.

## Problem
Lab 1 Ex 1 Task 1 step 16 tells learners to set the organization **Name** to "Adatum Corporation" and enter an address in the **Organization information** pane. On current trial tenants the org name can no longer be changed in the Microsoft 365 admin center (it's support-only), and some address fields moved to Billing → Billing accounts, so the step can't be completed as written.

## Fix
Softened the language so learners update fields only if they're editable and continue otherwise, and clarified that the displayed name may already be "Contoso" and that later labs work regardless of the org name shown. This is a light-touch wording change, not a flow rewrite.

## Related
Also addresses the downstream "shows Contoso not Adatum" observation in #166 (Lab 4), which stems from the org name being unchangeable.