### PR TITLE
Fix #146: update PIM role-settings navigation to current Roles path (Lab 4)

### DIFF
--- a/Instructions/Labs/LAB_AK_04_Lab4_Ex2_PIM_Admin_Approval.md
+++ b/Instructions/Labs/LAB_AK_04_Lab4_Ex2_PIM_Admin_Approval.md
@@ -57,13 +57,13 @@ Holly also wants to update the notification settings for the Global admin role. 
 
 7. In the **Privileged Identity Management | Quick start** window, in the middle pane under the **Manage** section, select **Microsoft Entra roles**.
 
-8. In the **Adatum Corporation | Quick start** window, in the middle pane under the **Manage** section, select **Settings**. 
+8. In the **Adatum Corporation | Quick start** window, in the middle pane under the **Manage** section, select **Roles**. 
 
-9. In the **Adatum Corporation | Settings** window, select the **Global Administrator** role. <br/>
+9. In the **Adatum Corporation | Roles** window, select the **Global Administrator** role. <br/>
 
     **Tip:** If the roles are not displayed in alphabetical order, select the **Role** heading to sort them in ascending alphabetical order. This will make it easier to locate the Global administrator role.
 
-10. In the **Role setting details -  Global Administrator** window, scroll through the page and review the information for role activation, assignment, and notification. Then select **Edit** on the menu bar at the top of the page.
+10. On the **Global Administrator** role page, select **Role settings**. Scroll through the page and review the information for role activation, assignment, and notification. Then select **Edit** on the menu bar at the top of the page.
 
 11. In the **Edit role setting - Global Administrator** window, the **Activation** tab is displayed by default. In this tab, below the activation slider, verify the **Azure MFA** option is selected by default for the **On activation, require** setting (if it's not selected, then select it now). This will require that the person requesting activation of the role will have to sign in using multi-factor authentication to provide additional verification that they are who they say they are.
 
@@ -102,7 +102,7 @@ In this task, Holly will create a new, role-assignable security group for users 
 
 2. You will begin by creating a new, role-assignable security group called **PIM-Global-Administrators** in Microsoft Entra ID, and you will assign Patti as a member of the group. <br/>
 
-    In your **Edge** browser, you should still have the **Microsoft Entra admin center** open in a tab that's displaying the **Adatum Corporation | Settings** window from the prior task. In the navigation pane, select **Groups**, and then select **All groups**.
+    In your **Edge** browser, you should still have the **Microsoft Entra admin center** open in a tab from the prior task. In the navigation pane, select **Groups**, and then select **All groups**.
 
 3. In the **Groups | All groups** window, in the detail pane on the right, select **New group** in the menu bar.
 

--- a/Instructions/Labs/LAB_AK_04_Lab4_Ex3_PIM_Self_Approval.md
+++ b/Instructions/Labs/LAB_AK_04_Lab4_Ex3_PIM_Self_Approval.md
@@ -93,13 +93,13 @@ In the prior lab exercise involving the Global administrator role, Holly updated
 
 3. In the **Privileged Identity Management | Quick start** window, in the middle pane under the **Manage** section, select **Microsoft Entra roles**.
 
-4. In the **Adatum Corporation | Quick start** window, in the middle pane under the **Manage** section, select **Settings**. 
+4. In the **Adatum Corporation | Quick start** window, in the middle pane under the **Manage** section, select **Roles**. 
 
-5. In the **Adatum Corporation | Settings** window, select the **Helpdesk Administrator** role.  <br/>
+5. In the **Adatum Corporation | Roles** window, select the **Helpdesk Administrator** role.  <br/>
 
     **Tip:** If the roles are not displayed in alphabetical order, select the **Role** heading to sort them in ascending alphabetical order. This will make it easier to locate the Helpdesk administrator role.
 
-6. In the **Role setting details -  Helpdesk Administrator** window, scroll through the page and review the information for role activation, assignment, and notification. Then select **Edit** on the menu bar at the top of the page.
+6. On the **Helpdesk Administrator** role page, select **Role settings**. Scroll through the page and review the information for role activation, assignment, and notification. Then select **Edit** on the menu bar at the top of the page.
 
 7. In the **Edit role setting - Helpdesk Administrator** window, the **Activation** tab is displayed by default. In this tab, the slider for the **Activation maximum duration (hours)** setting is set to **8**. Holly wants to increase this to the maximum allowable time, which is **24** hours. You can either move the slider to the end of the line, or you can type **24** in the field next to the slider. <br/>
 
@@ -174,7 +174,7 @@ At this point in Holly's pilot project, the **PIM-Helpdesk-Administrators** grou
 
 13. In the **Active assignments** tab, note the **Helpdesk Administrator** role now appears. Prior to activating this role, remember that you checked this tab earlier and no Microsoft Entra roles appeared. Now that Alex has self-approved the **Helpdesk Administrator** role, it's now been assigned to his user account. 
 
-14. Close the InPrivate browser session. This should return you to the **Microsoft Entra admin center**, which should be displaying the **Adatum Corporation | Settings** page.
+14. Close the InPrivate browser session. This should return you to the **Microsoft Entra admin center**.
 
 15. Leave your browser and all tabs open for the next task.
 

--- a/Instructions/Labs/LAB_AK_04_Lab4_Ex4_PIM_Teammate_Approval.md
+++ b/Instructions/Labs/LAB_AK_04_Lab4_Ex4_PIM_Teammate_Approval.md
@@ -92,13 +92,13 @@ As in the prior PIM exercise involving the Helpdesk admin role, Holly is trustin
 
 3. In the **Privileged Identity Management | Quick start** window, in the middle pane under the **Manage** section, select **Microsoft Entra roles**.
 
-4. In the **Adatum Corporation | Quick start** window, in the middle pane under the **Manage** section, select **Settings**. 
+4. In the **Adatum Corporation | Quick start** window, in the middle pane under the **Manage** section, select **Roles**. 
 
-5. In the **Adatum Corporation | Settings** window, select the **Intune Administrator** role.    <br/>
+5. In the **Adatum Corporation | Roles** window, select the **Intune Administrator** role.    <br/>
 
     **Tip:** If the roles are not displayed in alphabetical order, select the **Role** heading to sort them in ascending alphabetical order. This will make it easier to locate the Intune administrator role.
 
-6. In the **Role setting details -  Intune Administrator** window, scroll through the page and review the information for role activation, assignment, and notification. Then select **Edit** on the menu bar at the top of the page.
+6. On the **Intune Administrator** role page, select **Role settings**. Scroll through the page and review the information for role activation, assignment, and notification. Then select **Edit** on the menu bar at the top of the page.
 
 7. Below the activation slider, set the **On activation, require** setting to **None**. <br/>
 


### PR DESCRIPTION
Fixes #146.

## Problem
In the Microsoft Entra roles PIM experience, the blade no longer exposes a **Settings** node to reach role settings. Lab 4 Ex 2/3/4 still navigate `Microsoft Entra roles > Settings > [role]`, which doesn't match the current portal (reporter flagged "Adatum Corporation → Settings is not correct").

## Fix
Updated the navigation to the current path, verified against [Configure Microsoft Entra role settings in PIM](https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-change-default-settings): `Microsoft Entra roles > **Roles** > select the role > **Role settings** > Edit`.

Changed in all three PIM exercises:
- **Ex 2** (Global Administrator) — steps 8–10
- **Ex 3** (Helpdesk Administrator) — steps 4–6
- **Ex 4** (Intune Administrator) — steps 4–6

Also softened two stale "Adatum Corporation | Settings window" carryover references (Ex 2 Task 2, Ex 3 step 14) that pointed back to the removed Settings node.

## Note for reviewers
The navigation **path** is docs-verified. The exact intermediate **blade labels** (e.g., whether "Role settings" is a left-nav node vs. a button on the role page, and the "Adatum Corporation | …" prefix) are best confirmed on a live tenant, since portal chrome shifts faster than docs. Left the separate PIM **assignment** flow (Assign Eligibility → Roles) and the **Resource audit** validation steps unchanged, as they weren't part of this report.